### PR TITLE
Complext String Types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/iwillspeak/ullage"
 readme = "README.md"
 keywords = [ "llvm", "parser", "compiler" ]
 categories = [ "parsing" ]
-edition = "2015"
+edition = "2018"
 
 [dependencies]
 llvm-sys = "70"

--- a/README.md
+++ b/README.md
@@ -60,11 +60,12 @@ Ullage is open source, under the [MIT License](LICENSE.md).
 
  * [x] Create LLVM module and lower basic constructs
  * [ ] Array indexing
- * [ ] Arbitrary types for local variables
+ * [x] Arbitrary types for local variables
  * [ ] Heap allocated types
-    * [ ] Lowering of `String` type
-    * [ ] User-defined heap allocated types
-    * [ ] Garbage collection ??
- * [ ] Library output types
- * [ ] Control of target machine & features
+    * [x] Lowering of `String` type
+    * [ ] User-defined types
+    * [ ] RC garbage collection
+ * [ ] Library output types (llvm_ir, llvm bc, object, staticlib, dylib, exe)
+ * [x] Control of target machine & features
+ * [x] Optimisation
  * [ ] Stop shelling out for linking on supported platforms (lld or similar)

--- a/build.sh
+++ b/build.sh
@@ -4,6 +4,12 @@ set -e
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
+if [ ! -d ${DIR}/venv ]
+then
+	virtualenv venv
+	pip install -r ${DIR}/requirements.txt
+fi
+
 source ${DIR}/venv/bin/activate
 
 invoke "$@"

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,9 @@
+#! /usr/bin/env bash
+
+set -e
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+source ${DIR}/venv/bin/activate
+
+invoke "$@"

--- a/docs/10-syntax.md
+++ b/docs/10-syntax.md
@@ -150,7 +150,7 @@ An index expression uses `[]` to access elements from an array. Array indices st
 
 ```
 let fuzz = [1, 2, 3, 4]
-print fuzz[2] # => 2
+print fuzz[2] # => 3
 ```
 
 ### Call Expression

--- a/docs/15-data-layout.md
+++ b/docs/15-data-layout.md
@@ -17,7 +17,7 @@ For the primitive types we have the following type layouts from language type to
 
 String types should be represented as a pair of length, data:
 
- * `String` -> `<{u64,[0 x u8]}>`
+ * `String` -> `<{u32,[0 x u8]}>`
 
 This would have the value of the string be encoded directly as part of the pair. Allocation of a string would use a variable length array to contain a sequence of utf-8 characters. There are a few problems with this:
 
@@ -27,9 +27,11 @@ This would have the value of the string be encoded directly as part of the pair.
  
  Given these concernes we could lay a string out as:
  
-  * `String` -> `<{u32, <{u32, [0 x u8]}>*}>`
+  * `String` -> `<{u32, u32, [0 x u8]}>*`
 
 In this representation each string has a pointer to a reference counted backing buffer. This should reduce copy-size of each string and means that a string reference would again have a single easily known size. We still need to know when the reference should be deallocated however.
+
+The other thing to think about here is are 32 bit rc and length too big? Can we get away with 16 bit numbers for string length? For refcount we could always detect the overflow on retain and dupe the value as-needed to maintain correctness.
 
 ## Garbage Collection
 

--- a/spec/string_concat.ulg
+++ b/spec/string_concat.ulg
@@ -1,0 +1,3 @@
+print 'hello' # => hello
+print 'world' # => world
+print 'hello' + ' world' # => hello world

--- a/spec/string_concat.ulg
+++ b/spec/string_concat.ulg
@@ -1,3 +1,8 @@
 print 'hello' # => hello
 print 'world' # => world
 print 'hello' + ' world' # => hello world
+
+let space: String = ' '
+let foobar: String = 'foo' + ' ' + 'bar'
+
+print foobar # => foo bar

--- a/src/compile/lower.rs
+++ b/src/compile/lower.rs
@@ -138,7 +138,7 @@ pub fn lower_internal(
                     &mut [ctx.llvm_ctx.const_int(0), ctx.llvm_ctx.const_int(0)],
                 );
                 Ok(ctx.llvm_ctx.const_struct(vec![
-                    ctx.llvm_ctx.const_int(s.bytes().len() as i64),
+                    ctx.llvm_ctx.const_int_width(s.bytes().len() as i64, 32),
                     str_ptr,
                 ]))
             }
@@ -199,7 +199,7 @@ pub fn lower_internal(
             let cond = lower_internal(ctx, fun, builder, vars, *iff)?;
 
             // TODO: Get rid of the fallback types here
-            let typ = then
+            let typ = expr
                 .typ
                 .and_then(|t| ctx.llvm_type(&t))
                 .unwrap_or_else(|| ctx.llvm_ctx.int_type(64));

--- a/src/compile/lower.rs
+++ b/src/compile/lower.rs
@@ -364,7 +364,11 @@ fn build_string_concat(
     );
     string_copy_guts(ctx, builder, res, suf, suf_len, pre_len);
 
-    res
+    builder.build_bitcast(
+        res,
+        ctx.llvm_type(&Typ::Builtin(BuiltinType::String)).unwrap(),
+        "catenated"
+    )
 }
 
 /// Format with Printf

--- a/src/compile/lower.rs
+++ b/src/compile/lower.rs
@@ -197,11 +197,10 @@ pub fn lower_internal(
         ExpressionKind::IfThenElse(iff, then, els) => {
             let cond = lower_internal(ctx, fun, builder, vars, *iff)?;
 
-            // TODO: Get rid of the fallback types here
             let typ = expr
                 .typ
                 .and_then(|t| ctx.llvm_type(&t))
-                .unwrap_or_else(|| ctx.llvm_ctx.int_type(64));
+                .ok_or(CompError::from("No type for if expression".to_string()))?;
             let ret = builder.build_alloca(typ, "if");
 
             let thenblock = ctx.llvm_ctx.add_block(fun, "thenblock");

--- a/src/compile/lower.rs
+++ b/src/compile/lower.rs
@@ -368,13 +368,8 @@ fn fmt_from_type(
         Typ::Builtin(BuiltinType::String) => {
             // TODO: This is a faff. Need to change string types to be
             // a bit more ergonomic...
-            let string_type = ctx.llvm_type(&typ).unwrap();
-            let temp = builder.build_alloca(string_type, "string_gep_temp");
-            builder.build_store(val, temp);
-            let len = builder.build_struct_gep(temp, 0);
-            let len = builder.build_load(len);
-            let ptr = builder.build_struct_gep(temp, 1);
-            let ptr = builder.build_load(ptr);
+            let len = builder.build_extract_value(val, 0);
+            let ptr = builder.build_extract_value(val, 1);
             Some((vec![len, ptr], "printf_ustr_format"))
         }
         _ => None,

--- a/src/compile/lower.rs
+++ b/src/compile/lower.rs
@@ -366,9 +366,15 @@ fn fmt_from_type(
         }
         Typ::Builtin(BuiltinType::Number) => Some((vec![val], "printf_num_format")),
         Typ::Builtin(BuiltinType::String) => {
-            // fixme: load these from the string structure...
-            let len = ctx.llvm_ctx.const_int(0);
-            let ptr = ctx.llvm_ctx.const_int(0);
+            // TODO: This is a faff. Need to change string types to be
+            // a bit more ergonomic...
+            let string_type = ctx.llvm_type(&typ).unwrap();
+            let temp = builder.build_alloca(string_type, "string_gep_temp");
+            builder.build_store(val, temp);
+            let len = builder.build_struct_gep(temp, 0);
+            let len = builder.build_load(len);
+            let ptr = builder.build_struct_gep(temp, 1);
+            let ptr = builder.build_load(ptr);
             Some((vec![len, ptr], "printf_ustr_format"))
         }
         _ => None,

--- a/src/compile/lower_context.rs
+++ b/src/compile/lower_context.rs
@@ -35,9 +35,13 @@ impl<'a> LowerContext<'a> {
 
     pub fn add_core_types(&mut self) {
         // TODO: Unit -> void
-        // FIXME: String -> (len, [u8])
         let llvm_string = self.llvm_ctx.cstr_type();
-        self.add_type(Typ::Builtin(BuiltinType::String), llvm_string);
+        let lang_string = self.llvm_ctx.struct_type(vec![
+            // FIXME: Bit too big for string length?
+            self.llvm_ctx.int_type(64),
+            llvm_string,
+        ]);
+        self.add_type(Typ::Builtin(BuiltinType::String), lang_string);
         let llvm_bool = self.llvm_ctx.bool_type();
         self.add_type(Typ::Builtin(BuiltinType::Bool), llvm_bool);
         let llvm_number = self.llvm_ctx.int_type(64);

--- a/src/compile/lower_context.rs
+++ b/src/compile/lower_context.rs
@@ -36,11 +36,9 @@ impl<'a> LowerContext<'a> {
     pub fn add_core_types(&mut self) {
         // TODO: Unit -> void
         let llvm_string = self.llvm_ctx.cstr_type();
-        let lang_string = self.llvm_ctx.struct_type(vec![
-            // FIXME: Bit too big for string length?
-            self.llvm_ctx.int_type(64),
-            llvm_string,
-        ]);
+        let lang_string = self
+            .llvm_ctx
+            .struct_type(vec![self.llvm_ctx.int_type(32), llvm_string]);
         self.add_type(Typ::Builtin(BuiltinType::String), lang_string);
         let llvm_bool = self.llvm_ctx.bool_type();
         self.add_type(Typ::Builtin(BuiltinType::Bool), llvm_bool);

--- a/src/compile/lower_context.rs
+++ b/src/compile/lower_context.rs
@@ -16,6 +16,7 @@ pub struct LowerContext<'a> {
     pub llvm_ctx: &'a mut Context,
     /// The LLVM Module this context is building IR into.
     pub module: &'a mut Module,
+
     /// Map of Ty values to LLVM Types
     ty_map: HashMap<Typ, LLVMTypeRef>,
 }
@@ -33,8 +34,27 @@ impl<'a> LowerContext<'a> {
         }
     }
 
+    /// Add LLVM Intrinsic Declarations
+    ///
+    /// Updates the module to add declarations for the LLVM intrinsics
+    /// we care about. Need to find a better way to create these.
+    pub fn add_intrinsics(&mut self) {
+        let i8ptr = self.llvm_ctx.pointer_type(self.llvm_ctx.int_type(8));
+        let i32ty = self.llvm_ctx.int_type(32);
+
+        self.llvm_ctx.add_function(
+            self.module,
+            "llvm.memcpy.p0i8.p0i8.i32",
+            self.llvm_ctx.void_type(),
+            &mut vec![i8ptr, i8ptr, i32ty, self.llvm_ctx.bool_type()],
+        );
+    }
+
+    /// Add Core LLVM Types
+    ///
+    /// Adds entries to the type map for the bulitin types mappign
+    /// them to their underlying LLVM representation.
     pub fn add_core_types(&mut self) {
-        // TODO: Unit -> void
         let lang_string = self.llvm_ctx.pointer_type(self.llvm_ctx.struct_type(vec![
             self.llvm_ctx.int_type(32),
             self.llvm_ctx.array_type(self.llvm_ctx.int_type(8), 0),

--- a/src/compile/lower_context.rs
+++ b/src/compile/lower_context.rs
@@ -35,10 +35,10 @@ impl<'a> LowerContext<'a> {
 
     pub fn add_core_types(&mut self) {
         // TODO: Unit -> void
-        let llvm_string = self.llvm_ctx.cstr_type();
-        let lang_string = self
-            .llvm_ctx
-            .struct_type(vec![self.llvm_ctx.int_type(32), llvm_string]);
+        let lang_string = self.llvm_ctx.pointer_type(self.llvm_ctx.struct_type(vec![
+            self.llvm_ctx.int_type(32),
+            self.llvm_ctx.array_type(self.llvm_ctx.int_type(8), 0),
+        ]));
         self.add_type(Typ::Builtin(BuiltinType::String), lang_string);
         let llvm_bool = self.llvm_ctx.bool_type();
         self.add_type(Typ::Builtin(BuiltinType::Bool), llvm_bool);

--- a/src/compile/mod.rs
+++ b/src/compile/mod.rs
@@ -16,6 +16,7 @@ pub mod options;
 
 mod lower;
 mod lower_context;
+mod string_builtins;
 
 /// Add the Core Declarations to the Module
 ///
@@ -84,6 +85,7 @@ impl Compilation {
 
         let fun = {
             let mut lower_ctx = lower_context::LowerContext::new(&mut ctx, &mut module);
+            lower_ctx.add_intrinsics();
             lower_ctx.add_core_types();
             lower::lower_as_main(&mut lower_ctx, self.expr)?
         };

--- a/src/compile/mod.rs
+++ b/src/compile/mod.rs
@@ -25,6 +25,7 @@ fn add_core_decls(ctx: &mut Context, module: &mut Module) -> CompResult<()> {
     add_printf_decl(ctx, module);
     module.add_global(ctx.const_str("%d\n"), "printf_num_format");
     module.add_global(ctx.const_str("%s\n"), "printf_cstr_format");
+    module.add_global(ctx.const_str("%.*s\n"), "printf_ustr_format");
     module.add_global(ctx.const_str("true"), "print_true");
     module.add_global(ctx.const_str("false"), "print_false");
     Ok(())

--- a/src/compile/options.rs
+++ b/src/compile/options.rs
@@ -85,7 +85,7 @@ impl OptimisationLevel {
     /// Retrieves a (level, size) tuple which defines how to configure
     /// the LLVM optimiser for this optimisation level.
     pub fn unpack(&self) -> Option<(pm::OptLevel, pm::OptSize)> {
-        use OptimisationLevel::*;
+        use crate::OptimisationLevel::*;
         match self {
             Off => None,
             Low => Some((pm::OptLevel::Low, pm::OptSize::Off)),

--- a/src/compile/string_builtins.rs
+++ b/src/compile/string_builtins.rs
@@ -1,0 +1,65 @@
+//! String Builtins
+//!
+//! This module contains logic for interacting with string values.
+
+use super::lower_context::LowerContext;
+use crate::low_loader::prelude::*;
+
+/// String Copy Guts
+///
+/// Copies the body of a source string into a destiation string's
+/// buffer. This is used by the lowering of stirng concatentation.
+pub(crate) fn string_copy_guts(
+    ctx: &mut LowerContext,
+    builder: &mut Builder,
+    dest: LLVMValueRef,
+    src: LLVMValueRef,
+    len: LLVMValueRef,
+    offset: LLVMValueRef,
+) {
+    let memcpy = ctx
+        .module
+        .find_function("llvm.memcpy.p0i8.p0i8.i32")
+        .expect("can't find memcpy intrinsic");
+
+    let src_buffer = string_get_buffer(builder, src);
+    let src_buffer = builder.build_gep(
+        src_buffer,
+        &mut vec![ctx.llvm_ctx.const_int(0), ctx.llvm_ctx.const_int(0)],
+    );
+    let dest_buffer = string_get_buffer(builder, dest);
+    let dest_buffer = builder.build_gep(dest_buffer, &mut vec![ctx.llvm_ctx.const_int(0), offset]);
+
+    builder.build_void_call(
+        &memcpy,
+        &mut vec![dest_buffer, src_buffer, len, ctx.llvm_ctx.const_bool(false)],
+    );
+}
+
+/// Get String's Buffer Pointer
+///
+/// Returns a poitner to the buffer which contains the `String`'s
+/// body. This is a `[0 x i8]*`. It can be converted into a poitner to
+/// a given character offset with a GEP instruction]
+pub(crate) fn string_get_buffer(builder: &mut Builder, s: LLVMValueRef) -> LLVMValueRef {
+    builder.build_struct_gep(s, 1)
+}
+
+/// Get String Length
+///
+/// Reads the length field out of the `String`'s internal
+/// representation. This is a constant-time operation and returns the
+/// length in bytes.
+pub(crate) fn string_get_len(builder: &mut Builder, val: LLVMValueRef) -> LLVMValueRef {
+    let len_field = builder.build_struct_gep(val, 0);
+    builder.build_load(len_field)
+}
+
+/// Set Stirng Length
+///
+/// Set the internal string length field to a new value.
+pub(crate) fn string_set_len(builder: &mut Builder, val: LLVMValueRef, size: LLVMValueRef) {
+    let len_field = builder.build_struct_gep(val, 0);
+    builder.build_store(size, len_field);
+}
+

--- a/src/low_loader/builder.rs
+++ b/src/low_loader/builder.rs
@@ -113,6 +113,15 @@ impl Builder {
         }
     }
         
+    /// Extract a Value from an Aggregate
+    ///
+    /// Reads a value from a structure at the given struct offset.
+    pub fn build_extract_value(&mut self, struct_val: LLVMValueRef, index: u32) -> LLVMValueRef {
+        unsafe {
+            let name = CStr::from_bytes_with_nul_unchecked(b"extracted\0");
+            core::LLVMBuildExtractValue(self.raw, struct_val, index as c_uint, name.as_ptr())
+        }
+    }
 
     /// Build an Integer Negation
     pub fn build_neg(&mut self, value: LLVMValueRef) -> LLVMValueRef {

--- a/src/low_loader/builder.rs
+++ b/src/low_loader/builder.rs
@@ -103,6 +103,17 @@ impl Builder {
         }
     }
 
+    /// Build a Structure GEP
+    ///
+    /// Loads an element from a given structure pointer.
+    pub fn build_struct_gep(&mut self, struct_val: LLVMValueRef, index: u32) -> LLVMValueRef {
+        unsafe {
+            let name = CStr::from_bytes_with_nul_unchecked(b"sgep\0");
+            core::LLVMBuildStructGEP(self.raw, struct_val, index as c_uint, name.as_ptr())
+        }
+    }
+        
+
     /// Build an Integer Negation
     pub fn build_neg(&mut self, value: LLVMValueRef) -> LLVMValueRef {
         unsafe {

--- a/src/low_loader/builder.rs
+++ b/src/low_loader/builder.rs
@@ -112,7 +112,7 @@ impl Builder {
             core::LLVMBuildStructGEP(self.raw, struct_val, index as c_uint, name.as_ptr())
         }
     }
-        
+
     /// Extract a Value from an Aggregate
     ///
     /// Reads a value from a structure at the given struct offset.

--- a/src/low_loader/context.rs
+++ b/src/low_loader/context.rs
@@ -282,6 +282,21 @@ impl Context {
         }
     }
 
+    /// Create an Array Type
+    ///
+    /// Returns a type which represents a contiguous array of the
+    /// inner type.
+    pub fn array_type(&self, inner: LLVMTypeRef, size: usize) -> LLVMTypeRef {
+        unsafe { core::LLVMArrayType(inner, size as c_uint) }
+    }
+
+    /// Create a Pointer Type
+    ///
+    /// Wraps a given type to creat a poitner to it.
+    pub fn pointer_type(&self, inner: LLVMTypeRef) -> LLVMTypeRef {
+        unsafe { core::LLVMPointerType(inner, 0) }
+    }
+
     /// Get the LLVM Type from a Value
     ///
     /// Inspects a given LLVM Value and returns the type as known by

--- a/src/low_loader/context.rs
+++ b/src/low_loader/context.rs
@@ -209,6 +209,16 @@ impl Context {
         }
     }
 
+    /// Create a Structure Contstant
+    ///
+    /// Initialses a new structrure based on the given values.
+    pub fn const_struct(&self, mut values: Vec<LLVMValueRef>) -> LLVMValueRef {
+        let len = values.len();
+        unsafe {
+            core::LLVMConstStructInContext(self.as_raw(), values.as_mut_ptr(), len as c_uint, 0)
+        }
+    }
+
     /// Raw Borrow
     ///
     /// # Safety
@@ -248,6 +258,17 @@ impl Context {
         unsafe {
             let int8 = core::LLVMInt8TypeInContext(self.as_raw());
             core::LLVMPointerType(int8, 0)
+        }
+    }
+
+    /// Create a Structure Type
+    ///
+    /// Given a set of fields create a structure type with fields
+    /// layed out in that order.
+    pub fn struct_type(&self, mut fields: Vec<LLVMTypeRef>) -> LLVMTypeRef {
+        let len = fields.len();
+        unsafe {
+            core::LLVMStructTypeInContext(self.as_raw(), fields.as_mut_ptr(), len as c_uint, 0)
         }
     }
 

--- a/src/low_loader/context.rs
+++ b/src/low_loader/context.rs
@@ -297,6 +297,11 @@ impl Context {
         unsafe { core::LLVMPointerType(inner, 0) }
     }
 
+    /// Get the Void Type
+    pub fn void_type(&self) -> LLVMTypeRef {
+        unsafe { core::LLVMVoidTypeInContext(self.0) }
+    }
+
     /// Get the LLVM Type from a Value
     ///
     /// Inspects a given LLVM Value and returns the type as known by

--- a/src/low_loader/context.rs
+++ b/src/low_loader/context.rs
@@ -176,6 +176,16 @@ impl Context {
         }
     }
 
+    /// Create a Constant Value with a Given Width
+    ///
+    /// Used when the width shouldn't be 64 bits.
+    pub fn const_int_width(&self, i: i64, width: u32) -> LLVMValueRef {
+        unsafe {
+            let int_ty = core::LLVMIntTypeInContext(self.as_raw(), width);
+            core::LLVMConstInt(int_ty, i as u64, 1)
+        }
+    }
+
     /// Create a Constant Character Value
     pub fn const_char(&self, i: u8) -> LLVMValueRef {
         unsafe {

--- a/src/sem/mod.rs
+++ b/src/sem/mod.rs
@@ -4,6 +4,7 @@
 //! representation of a program, as produced by the parser, into a
 //! semantically rich model ready to be lowered for execution.
 
+mod operators;
 mod sem_ctx;
 mod transform;
 mod tree;

--- a/src/sem/operators.rs
+++ b/src/sem/operators.rs
@@ -40,6 +40,14 @@ fn comp_op(op: InfixOp) -> Option<SemOp> {
 /// Searches for the result type for a given operator.
 pub fn find_builtin_op(op: InfixOp, lhs_typ: Typ, rhs_typ: Typ) -> Option<SemOp> {
     match (op, lhs_typ, rhs_typ) {
+        (InfixOp::Add, Typ::Builtin(BuiltinType::String), Typ::Builtin(BuiltinType::String)) => {
+            Some(SemOp {
+                lhs_typ,
+                rhs_typ,
+                op,
+                result_typ: Typ::Builtin(BuiltinType::String),
+            })
+        }
         (InfixOp::Add, Typ::Builtin(BuiltinType::Number), Typ::Builtin(BuiltinType::Number)) => {
             num_op(op)
         }

--- a/src/sem/operators.rs
+++ b/src/sem/operators.rs
@@ -1,0 +1,55 @@
+//! # Semantic Operators
+//!
+//! This module provides semantic undestanding of the builtin
+//! operators. The main entry point is the
+
+use super::types::{BuiltinType, Typ};
+use crate::syntax::operators::*;
+
+/// The Semantic Operator
+///
+/// Semantically bound operator. This is an operator with knowlege of
+/// the types it is to be bound to.
+pub struct SemOp {
+    pub lhs_typ: Typ,
+    pub rhs_typ: Typ,
+    pub op: InfixOp,
+    pub result_typ: Typ,
+}
+
+fn num_op(op: InfixOp) -> Option<SemOp> {
+    Some(SemOp {
+        lhs_typ: Typ::Builtin(BuiltinType::Number),
+        rhs_typ: Typ::Builtin(BuiltinType::Number),
+        op,
+        result_typ: Typ::Builtin(BuiltinType::Number),
+    })
+}
+
+fn comp_op(op: InfixOp) -> Option<SemOp> {
+    Some(SemOp {
+        lhs_typ: Typ::Builtin(BuiltinType::Number),
+        rhs_typ: Typ::Builtin(BuiltinType::Number),
+        op,
+        result_typ: Typ::Builtin(BuiltinType::Bool),
+    })
+}
+
+/// Find Operator
+///
+/// Searches for the result type for a given operator.
+pub fn find_builtin_op(op: InfixOp, lhs_typ: Typ, rhs_typ: Typ) -> Option<SemOp> {
+    match (op, lhs_typ, rhs_typ) {
+        (InfixOp::Add, Typ::Builtin(BuiltinType::Number), Typ::Builtin(BuiltinType::Number)) => {
+            num_op(op)
+        }
+        (InfixOp::Sub, _, _) | (InfixOp::Mul, _, _) | (InfixOp::Div, _, _) => num_op(op),
+
+        (InfixOp::Eq, _, _)
+        | (InfixOp::NotEq, _, _)
+        | (InfixOp::Lt, _, _)
+        | (InfixOp::Gt, _, _) => comp_op(op),
+
+        _ => None,
+    }
+}

--- a/src/sem/transform.rs
+++ b/src/sem/transform.rs
@@ -67,8 +67,8 @@ pub fn transform_expression(ctx: &mut SemCtx, expr: SyntaxExpr) -> CompResult<Ex
                 _ => {
                     let lhs = transform_expression(ctx, *lhs)?;
 
-                    let lhs_typ = ensure_ty(lhs.typ)?;
-                    let rhs_typ = ensure_ty(rhs.typ)?;
+                    let lhs_typ = relax_ty(lhs.typ);
+                    let rhs_typ = relax_ty(rhs.typ);
                     let found = find_builtin_op(op, lhs_typ, rhs_typ);
 
                     if let Some(operator) = found {
@@ -201,6 +201,15 @@ pub fn transform_expression(ctx: &mut SemCtx, expr: SyntaxExpr) -> CompResult<Ex
             ))
         }
     }
+}
+
+/// Relax Type
+///
+/// Returns the type if it is present, or assumes `Number`
+/// otherwise. This is a hack to deal with partially-typed trees and
+/// should be removed.
+fn relax_ty(maybe_typ: Option<Typ>) -> Typ {
+    maybe_typ.unwrap_or(Typ::Builtin(BuiltinType::Number))
 }
 
 /// Ensure Type

--- a/src/sem/transform.rs
+++ b/src/sem/transform.rs
@@ -52,10 +52,10 @@ pub fn transform_expression(ctx: &mut SemCtx, expr: SyntaxExpr) -> CompResult<Ex
             match op {
                 InfixOp::Assign => {
                     if let SyntaxExpr::Identifier(id) = *lhs {
-                        // TODO: look up the type of the identifier
+                        let id_typ = ctx.find_local(&id).or(rhs.typ);
                         Ok(Expression::new(
                             ExpressionKind::Assignment(id, Box::new(rhs)),
-                            None,
+                            id_typ,
                         ))
                     } else {
                         Err(CompError::from(String::from(

--- a/src/syntax/operators.rs
+++ b/src/syntax/operators.rs
@@ -5,7 +5,7 @@
 //! between these variants.
 
 /// Represents an AST prefix operator.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Copy, Clone)]
 pub enum PrefixOp {
     /// Unary Airthmetic Negation
     ///
@@ -23,7 +23,7 @@ pub enum PrefixOp {
 }
 
 /// Represents an AST infix operator
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Copy, Clone)]
 pub enum InfixOp {
     /// Assignment Operator (`=`)
     Assign,


### PR DESCRIPTION
Updates to make `String` types more than just a character pointer. The plan is to eventually
have strings as refcounted arrays with length prefixes. This PR aims to move in that direction by checking off some of the steps on that path:

 * [x] String type bcomes pointer to structure: `<{u32, [0xi8]}>*`
 * [x] Strings allocated on the heap with malloc and memcpy.
 * [x] String concatenation with `+`

By the end of this strings should start behaving like the complex value type they are. They will leak memory however as there is no plan to manage the refcounting needed to free the backing buffer yet.
