### PR TITLE
Benchmarking

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,15 @@ You can also mess around with constant strings:
         print_num(n)
     end
 
+## Building and Testing
+
+The main build is performed by `cargo`. For running the functional
+tests and benchmarks you'll need Python. The suggested process is to use the `build.sh` script:
+
+ * `$ ./build.sh` will build the compiler `target/release/ullage`.
+ * `$ ./build.sh test` will build the compiler and run the test suite from `specs/`.
+ * `$ ./build.sh bench` will run the benchmarks from `spec/bench/`.
+
 ## License
 
 Ullage is open source, under the [MIT License](LICENSE.md).

--- a/spec/bench/README.md
+++ b/spec/bench/README.md
@@ -1,0 +1,14 @@
+# Benchmarking
+
+This folder contains files which can be used to benchmark the
+performance of the generated code. Each file should have a `#!!skip`
+attribute so that they aren't run when the spec tests are executed.
+
+The benchkarks can be run with `./build.sh bench` from the project
+root.
+
+## `fib.ulg`
+
+This benchmark performs the same Fibonacci computation from
+<https://github.com/drujensen/fib> to allow some form of comparision
+with popular lanugages.

--- a/spec/bench/fib.ulg
+++ b/spec/bench/fib.ulg
@@ -1,0 +1,7 @@
+#!!skip
+
+fn fib(n: Number): Number
+   1 if n < 2 else fib(n - 1) + fib(n - 2)
+end
+
+print fib(46) # => 

--- a/spec/printing.ulg
+++ b/spec/printing.ulg
@@ -19,3 +19,14 @@ fn print_str(s: String): String
 end
 
 print_str('hello') # => hello
+
+## Tests for printing out 'large' numbers. This makes sure we print
+## out 64 bit values correctly
+print 2147483647 # => 2147483647
+print -2147483648 # => -2147483648
+print 2971215073 # => 2971215073
+print 9223372036854775807 #=> 9223372036854775807
+# Since negative integers aren't actually literals, just applications
+# of a prefix operator we can't actually _write_ the value in
+# full. Instead compute it.
+print -9223372036854775807 - 1 # => -9223372036854775808

--- a/src/compile/mod.rs
+++ b/src/compile/mod.rs
@@ -24,7 +24,7 @@ mod string_builtins;
 /// declarations/definitions of any builtin funtions are emitted.
 fn add_core_decls(ctx: &mut Context, module: &mut Module) -> CompResult<()> {
     add_printf_decl(ctx, module);
-    module.add_global(ctx.const_str("%d\n"), "printf_num_format");
+    module.add_global(ctx.const_str("%lld\n"), "printf_num_format");
     module.add_global(ctx.const_str("%s\n"), "printf_cstr_format");
     module.add_global(ctx.const_str("%.*s\n"), "printf_ustr_format");
     module.add_global(ctx.const_str("true"), "print_true");

--- a/tasks.py
+++ b/tasks.py
@@ -1,4 +1,6 @@
 from invoke import task
+import os
+import glob
 
 @task
 def clean(ctx):
@@ -7,8 +9,9 @@ def clean(ctx):
     ctx.run("cargo clean")
 
 @task(default=True)
-def build(ctx):
-    ctx.run("cargo build")
+def build(ctx, release=True):
+    mode = "--release" if release else "--debug"
+    ctx.run("cargo build " + mode)
 
 @task
 def docs(ctx):
@@ -19,3 +22,18 @@ def docs(ctx):
 def test(ctx):
     ctx.run("cargo test")
     ctx.run("python specs.py")
+
+@task(build)
+def bench(ctx, opt_level=3):
+    for bench in glob.glob("spec/bench/*.ulg"):
+        output = bench.lstrip('spec/').rstrip('.ulg')
+        output = os.path.join("specbin", "bench", output)
+        try:
+            os.makedirs(os.path.dirname(output))
+        except OSError:
+            pass
+        print "bench={0}, output={1}, opt={2}".format(bench, output, opt_level)
+        ctx.run("target/release/ullage {0} -O{1} -o {2}"
+                .format(bench, opt_level, output))
+        ctx.run("time {0}".format(output))
+


### PR DESCRIPTION
Adds a `fib.ulg` which uses naïve recursion. This matches the benchmarks in <https://github.com/drujensen/fib> as discussed in #20.

The current results on my `2.8 GHz Intel Core i7` MacBook Pro:

```
bench=spec/bench/fib.ulg, output=specbin/bench/bench/fib, opt=3
2971215073

real	0m7.791s
user	0m7.784s
sys	0m0.004s
```

Not too shabby!

The PR also addresses a bug uncovered in printing large numbers during the writing of this benchmark and lays the groundwork for including further benchmakrs in future.

Fixes #20 